### PR TITLE
TASK: Remove arguments from VH render methods

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,9 @@
+preset: psr2
+
+finder:
+  path:
+    - "Classes"
+
+enabled:
+  - short_array_syntax
+  - no_unused_imports

--- a/Classes/ViewHelpers/AbstractComponentViewHelper.php
+++ b/Classes/ViewHelpers/AbstractComponentViewHelper.php
@@ -11,7 +11,6 @@ namespace Neos\Twitter\Bootstrap\ViewHelpers;
  * source code.
  */
 
-use Neos\Flow\Annotations as Flow;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\View\StandaloneView;
 

--- a/Classes/ViewHelpers/IncludeViewHelper.php
+++ b/Classes/ViewHelpers/IncludeViewHelper.php
@@ -12,6 +12,7 @@ namespace Neos\Twitter\Bootstrap\ViewHelpers;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -20,7 +21,7 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 class IncludeViewHelper extends AbstractViewHelper
 {
     /**
-     * @var \Neos\Flow\ResourceManagement\ResourceManager
+     * @var ResourceManager
      * @Flow\Inject
      */
     protected $resourceManager;
@@ -63,19 +64,19 @@ class IncludeViewHelper extends AbstractViewHelper
 
         $content = sprintf(
             '<link rel="stylesheet" href="%s" />' . PHP_EOL,
-            $this->resourceManager->getPublicPackageResourceUri('Neos.Twitter.Bootstrap', $version . '/css/bootstrap' . ($minified === TRUE ? '.min' : '') . '.css')
+            $this->resourceManager->getPublicPackageResourceUri('Neos.Twitter.Bootstrap', $version . '/css/bootstrap' . ($minified === true ? '.min' : '') . '.css')
         );
 
         if ($this->arguments['includeJQuery'] === true) {
             $content .= sprintf(
                 '<script src="%s"></script>' . PHP_EOL,
-                $this->resourceManager->getPublicPackageResourceUri('Neos.Twitter.Bootstrap', 'Libraries/jQuery/jquery-' . $jQueryVersion . ($minified === TRUE ? '.min' : '') . '.js')
+                $this->resourceManager->getPublicPackageResourceUri('Neos.Twitter.Bootstrap', 'Libraries/jQuery/jquery-' . $jQueryVersion . ($minified === true ? '.min' : '') . '.js')
             );
         }
 
         $content .= sprintf(
             '<script src="%s"></script>' . PHP_EOL,
-            $this->resourceManager->getPublicPackageResourceUri('Neos.Twitter.Bootstrap', $version . '/js/bootstrap' . ($minified === TRUE ? '.min' : '') . '.js')
+            $this->resourceManager->getPublicPackageResourceUri('Neos.Twitter.Bootstrap', $version . '/js/bootstrap' . ($minified === true ? '.min' : '') . '.js')
         );
 
         return $content;

--- a/Classes/ViewHelpers/IncludeViewHelper.php
+++ b/Classes/ViewHelpers/IncludeViewHelper.php
@@ -31,6 +31,21 @@ class IncludeViewHelper extends AbstractViewHelper
     protected $escapeOutput = false;
 
     /**
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('version', 'string', 'The version to use, for example "2.2", "3.0" or also "2" or "3" meaning "2.x" and "3.x" respectively', true);
+        $this->registerArgument('minified', 'string', 'If the minified version of Twitter Bootstrap should be used', false, true);
+        $this->registerArgument('includeJQuery', 'string', 'If enabled, also includes jQuery', false, false);
+        $this->registerArgument('jQueryVersion', 'string', 'The jQuery version to include', false, '1.10.1');
+    }
+
+    /**
      * Get the header include code for including Twitter Bootstrap on a page. If needed
      * the jQuery library can be included, too.
      *
@@ -38,20 +53,20 @@ class IncludeViewHelper extends AbstractViewHelper
      * {namespace bootstrap=Neos\Twitter\Bootstrap\ViewHelpers}
      * <bootstrap:include />
      *
-     * @param string $version The version to use, for example "2.2", "3.0" or also "2" or "3" meaning "2.x" and "3.x" respectively
-     * @param boolean $minified If the minified version of Twitter Bootstrap should be used
-     * @param boolean $includeJQuery If enabled, also includes jQuery
-     * @param string $jQueryVersion The jQuery version to include
      * @return string
      */
-    public function render($version, $minified = TRUE, $includeJQuery = FALSE, $jQueryVersion = '1.10.1')
+    public function render(): string
     {
+        $version = $this->arguments['version'];
+        $minified = $this->arguments['minified'];
+        $jQueryVersion = $this->arguments['jQueryVersion'];
+
         $content = sprintf(
             '<link rel="stylesheet" href="%s" />' . PHP_EOL,
             $this->resourceManager->getPublicPackageResourceUri('Neos.Twitter.Bootstrap', $version . '/css/bootstrap' . ($minified === TRUE ? '.min' : '') . '.css')
         );
 
-        if ($includeJQuery === TRUE) {
+        if ($this->arguments['includeJQuery'] === true) {
             $content .= sprintf(
                 '<script src="%s"></script>' . PHP_EOL,
                 $this->resourceManager->getPublicPackageResourceUri('Neos.Twitter.Bootstrap', 'Libraries/jQuery/jquery-' . $jQueryVersion . ($minified === TRUE ? '.min' : '') . '.js')

--- a/Classes/ViewHelpers/Navigation/MenuViewHelper.php
+++ b/Classes/ViewHelpers/Navigation/MenuViewHelper.php
@@ -35,20 +35,31 @@ class MenuViewHelper extends AbstractComponentViewHelper
     }
 
     /**
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('items', 'array', 'Items to render', true);
+        $this->registerArgument('classNames', 'array', 'CSS classes to add to the menu', false, ['nav']);
+    }
+
+    /**
      * Render the menu
      *
-     * @param array $items
-     * @param array $classNames
      * @return string
      */
-    public function render(array $items, array $classNames = array('nav'))
+    public function render(): string
     {
         $view = $this->getView();
 
         $view->assignMultiple(array(
-            'items' => $items,
+            'items' => $this->arguments['items'],
             'settings' => $this->settings,
-            'menuClasses' => implode(' ', $classNames)
+            'menuClasses' => implode(' ', $this->arguments['classNames'])
         ));
 
         return $view->render();

--- a/Classes/ViewHelpers/Navigation/MenuViewHelper.php
+++ b/Classes/ViewHelpers/Navigation/MenuViewHelper.php
@@ -21,20 +21,6 @@ use Neos\Twitter\Bootstrap\ViewHelpers\AbstractComponentViewHelper;
 class MenuViewHelper extends AbstractComponentViewHelper
 {
     /**
-     * @var array
-     */
-    protected $settings;
-
-    /**
-     * @param array $settings
-     * @return void
-     */
-    public function injectSettings(array $settings)
-    {
-        $this->settings = $settings;
-    }
-
-    /**
      * Initialize the arguments.
      *
      * @return void
@@ -56,11 +42,11 @@ class MenuViewHelper extends AbstractComponentViewHelper
     {
         $view = $this->getView();
 
-        $view->assignMultiple(array(
+        $view->assignMultiple([
             'items' => $this->arguments['items'],
             'settings' => $this->settings,
             'menuClasses' => implode(' ', $this->arguments['classNames'])
-        ));
+        ]);
 
         return $view->render();
     }


### PR DESCRIPTION
This removes the arguments from `render()` in Fluid ViewHelpers, and
registers them using `registerArgument` instead.

Arguments to `render()` were deprecated as of Flow 4.0 and support
is removed with Flow 6.0.